### PR TITLE
Display JSON LD from Data Registry

### DIFF
--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import IPython.display\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/ld+json": {
+       "@id": "style.css",
+       "http://schema.org/name": "Some Name!"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "IPython.display.publish_display_data(\n",
+    "    {\"application/ld+json\": {\n",
+    "        \"@id\": \"style.css\",\n",
+    "        \"http://schema.org/name\": \"Some Name!\"\n",
+    "    }}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/x.jupyter.relative-dataset-urls+json": [
+       "style.css"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "IPython.display.publish_display_data(\n",
+    "    {\"application/x.jupyter.relative-dataset-urls+json\": [\"style.css\"]}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
   },
   "peerDependencies": {
     "@jupyterlab/dataregistry": "^3.0.0",
-    "@jupyterlab/dataregistry-extension": "^3.0.0"
+    "@jupyterlab/dataregistry-extension": "^3.0.0",
+    "rxjs": "^6.5.2"
   },
   "devDependencies": {
-    "@jupyterlab/dataregistry": "^3.0.0",
     "@jupyterlab/dataregistry-extension": "^3.0.0",
     "@types/jsonld": "1.5.0",
     "rimraf": "~2.6.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "allowSyntheticDefaultImports": true,
     "composite": true,
     "declaration": true,
+    "skipLibCheck": true,
     "esModuleInterop": true,
     "jsx": "react",
     "module": "esnext",
@@ -14,8 +15,9 @@
     "resolveJsonModule": true,
     "outDir": "lib",
     "rootDir": "src",
+    "lib": ["dom", "esnext"],
     "strict": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "target": "es2017",
     "types": []
   },


### PR DESCRIPTION
This PR adds support for viewing any JSON LD registered in the data registry in the linked data viewer.

Now in a notebook, if you output a `application/ld+json` mimetype, this data will be added to the data registry. Also if the `@id` is a relative URL, it will be resolved from the notebook URL.

<img width="1920" alt="Screen Shot 2019-10-05 at 12 32 50 AM" src="https://user-images.githubusercontent.com/1186124/66249851-d6709300-e707-11e9-9696-11d05f1ebb57.png">
