### PR TITLE
Remove duplicate action

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -8,6 +8,5 @@
 set -o errexit
 set -o xtrace
 
-jlpm install
 jlpm run build
 jupyter labextension link . @jupyterlab/dataregistry-extension

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "jsx": "react",
+    "lib": ["dom", "esnext"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "lib": ["dom", "esnext"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,


### PR DESCRIPTION
Running `jlpm run build` already runs `jlpm install`, so should be able to remove duplicate command.